### PR TITLE
fix(ci): add missing npm scripts and dependencies for CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       run: npm run test:coverage
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       if: matrix.node-version == '20.x'
       with:
         file: ./coverage/lcov.info
@@ -66,7 +66,7 @@ jobs:
       run: npm run build
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "node dist/index.js",
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "lint": "eslint src/**/*.ts",
-    "test": "jest"
+    "test": "jest",
+    "type-check": "tsc --noEmit",
+    "format:check": "prettier --check \"src/**/*.{ts,js}\"",
+    "test:coverage": "jest --coverage"
   },
   "keywords": ["gitlab", "webhook", "claude", "ai"],
   "author": "",
@@ -23,12 +26,15 @@
   },
   "devDependencies": {
     "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.8",
     "@types/node": "^20.10.4",
     "@types/uuid": "^9.0.7",
     "@typescript-eslint/eslint-plugin": "^6.13.2",
     "@typescript-eslint/parser": "^6.13.2",
     "eslint": "^8.55.0",
     "jest": "^29.7.0",
+    "prettier": "^3.1.0",
+    "ts-jest": "^29.1.1",
     "ts-node-dev": "^2.0.0",
     "typescript": "^5.3.3"
   }


### PR DESCRIPTION
This PR fixes CI/CD failures by adding missing npm scripts and dependencies that the GitHub Actions workflow expects:

- Add type-check script using tsc --noEmit
- Add format:check script using prettier
- Add test:coverage script for Jest coverage
- Add missing devDependencies: prettier, ts-jest, @types/jest

Resolves #2

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Tests
  * Introduced test coverage reporting and improved test tooling to ensure more reliable releases. Existing test command remains available.

* Chores
  * Added development scripts for type checking and formatting consistency to streamline local development and CI.
  * Included supporting development dependencies for testing and formatting. No changes to runtime behavior or user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->