### PR TITLE
Update default claude version to claude-sonnet-4-5-20250929

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ OPENAI_API_KEY=sk-proj-your-openai-key             # 必需 (使用 Codex 时)
 
 # AI 提供者配置 (可选，都有默认值)
 AI_DEFAULT_PROVIDER=claude                         # 可选，默认: claude
-CLAUDE_DEFAULT_MODEL=claude-sonnet-4-5-20250929    # 可选，默认: claude-sonnet-4-20250514
+CLAUDE_DEFAULT_MODEL=claude-sonnet-4-5-20250929    # 可选，默认: claude-sonnet-4-5-20250929
 CODEX_DEFAULT_MODEL=gpt-5.1-codex-max              # 可选，默认: gpt-5.1-codex-max
 CODEX_REASONING_EFFORT=high                        # 可选，默认: high
 

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@ OPENAI_API_KEY=sk-proj-your-openai-key             # 必需 (使用 Codex 时)
 
 # AI 提供者配置 (可选，都有默认值)
 AI_DEFAULT_PROVIDER=claude                         # 可选，默认: claude
-CLAUDE_DEFAULT_MODEL=claude-sonnet-4-20250514      # 可选，默认: claude-sonnet-4-20250514
+CLAUDE_DEFAULT_MODEL=claude-sonnet-4-5-20250929    # 可选，默认: claude-sonnet-4-20250514
 CODEX_DEFAULT_MODEL=gpt-5.1-codex-max              # 可选，默认: gpt-5.1-codex-max
 CODEX_REASONING_EFFORT=high                        # 可选，默认: high
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ OPENAI_API_KEY=sk-proj-your-openai-key
 
 # AI Provider Configuration (optional, all have defaults)
 AI_DEFAULT_PROVIDER=claude
-CLAUDE_DEFAULT_MODEL=claude-sonnet-4-20250514
+CLAUDE_DEFAULT_MODEL=claude-sonnet-4-5-20250929
 CODEX_DEFAULT_MODEL=gpt-5.1-codex-max
 CODEX_REASONING_EFFORT=high
 
@@ -147,7 +147,7 @@ Add to MR description or comment:
 Specify a specific model:
 
 ```
-@claude[model=claude-sonnet-4-20250514] Fix the TypeScript errors in the authentication module
+@claude[model=claude-sonnet-4-5-20250929] Fix the TypeScript errors in the authentication module
 ```
 
 ```
@@ -232,7 +232,7 @@ For detailed configuration instructions including environment variable expansion
 | `AI_DEFAULT_PROVIDER`  | Default AI provider            | `claude`                         |
 | `ANTHROPIC_BASE_URL`   | Anthropic API base URL         | `https://api.anthropic.com`      |
 | `OPENAI_BASE_URL`      | OpenAI API base URL            | `https://api.openai.com/v1`      |
-| `CLAUDE_DEFAULT_MODEL` | Default model for Claude       | `claude-sonnet-4-20250514`       |
+| `CLAUDE_DEFAULT_MODEL` | Default model for Claude       | `claude-sonnet-4-5-20250929`     |
 | `CODEX_DEFAULT_MODEL`  | Default model for Codex        | `gpt-5.1-codex-max`              |
 | `CODEX_REASONING_EFFORT` | Codex reasoning level        | `high`                           |
 | `GITLAB_BASE_URL`      | GitLab instance URL            | `https://gitlab.com`             |


### PR DESCRIPTION
Update CLAUDE_DEFAULT_MODEL version to latest model version `claude-sonnet-4-5-20250929` in `.env.example` and README.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the default Claude model version shown in configuration, usage examples, and documentation to the newer release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->