### PR TITLE
fix: preserve successful Claude terminal results

### DIFF
--- a/src/__tests__/runtimeConfigExecution.test.ts
+++ b/src/__tests__/runtimeConfigExecution.test.ts
@@ -349,6 +349,42 @@ describe('runtime config execution paths', () => {
     );
   });
 
+  it('stops consuming Claude messages after a successful terminal result', async () => {
+    jest.spyOn(runtimeConfigService, 'getConfig').mockReturnValue(createRuntimeConfig());
+
+    mockQuery.mockImplementation(() =>
+      (async function* () {
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: 'Review conclusion produced before the transport closed.',
+          total_cost_usd: 1.18,
+          num_turns: 48,
+          duration_ms: 719380,
+        };
+        throw new Error(
+          'Claude Code returned an error result: API Error: The operation timed out.'
+        );
+      })()
+    );
+
+    const executor = new StreamingClaudeExecutor();
+    const callback = createCallback();
+    const result = await executor.executeWithStreaming(
+      'review一下当前MR中的代码修改',
+      '/tmp/project',
+      createExecutionContext({ mode: 'review' }),
+      callback
+    );
+
+    expect(result).toEqual({
+      success: true,
+      output: 'Review conclusion produced before the transport closed.',
+      changes: [],
+    });
+    expect(callback.onError).not.toHaveBeenCalled();
+  });
+
   it('uses published admin Claude edit system prompt templates for ordinary requests', async () => {
     const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'claude-prompt-template-'));
     const customization = new ReviewCustomizationService({ dataDir });

--- a/src/services/streamingClaudeExecutor.ts
+++ b/src/services/streamingClaudeExecutor.ts
@@ -292,6 +292,7 @@ export class StreamingClaudeExecutor {
               turns: resultMsg.num_turns,
               durationMs: resultMsg.duration_ms,
             });
+            break;
           } else {
             const errors = 'errors' in resultMsg ? resultMsg.errors : [];
             const errorStr =


### PR DESCRIPTION
## Summary
- stop consuming Claude SDK messages after a successful terminal result
- preserve the successful review when the transport reports a later timeout
- add a regression test for the success-then-timeout sequence

## Verification
- npm test -- --runInBand --silent (239 tests)
- npm run type-check
- npx eslint --no-eslintrc -c .eslintrc.js "src/**/*.ts" (0 errors)
- npm run format:check
- npm run build
- bash scripts/verify-runtime-image-files.sh
- bash scripts/verify-deepflow-image-files.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Claude executions now stop processing messages immediately after a successful result.
  * Subsequent transport errors no longer override a completed successful execution or trigger unnecessary error handling.

* **Tests**
  * Added coverage confirming successful executions remain successful when later transport errors occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->